### PR TITLE
Fix first-time app initialization race condition

### DIFF
--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -34,8 +34,8 @@ export function Dashboard() {
           setIsProjectsLoading(true);
           const defaultProject = await projectManager.createProject('My First Project');
           
-          // Switch to the new project's database
-          await switchToProject(defaultProject.databasePath);
+          // Let useDatabase hook handle initialization when it detects the active project
+          // This prevents race condition between Dashboard and useDatabase initialization
           
           // Update state
           setProjects(projectManager.getProjects());


### PR DESCRIPTION
## Summary

- Fixes race condition during first-time app initialization that caused schema creation errors
- Removes automatic `switchToProject()` call from first project creation in Dashboard component
- Ensures single initialization path through useDatabase hook, consistent with how subsequent projects work

## Problem

When starting the app on a fresh machine with no existing projects, users encountered schema initialization errors:
- "Some roles already exist, continuing with schema creation" 
- "Schema initialization failed: schema 'auth' already exists"

Root cause was duplicate initialization attempts:
1. Dashboard creates first project → calls `switchToProject()`
2. useDatabase hook detects active project → calls `initialize()` concurrently
3. Both paths trigger database schema creation simultaneously → conflict

## Solution

Remove the automatic database switch from first project creation, letting useDatabase handle initialization cleanly. This makes first project creation work the same way as subsequent projects (which already work correctly).

## Test Plan

- [x] Remove problematic switchToProject call from Dashboard.tsx
- [ ] Test first-time app startup on fresh browser profile
- [ ] Verify single initialization path in console logs
- [ ] Confirm no "schema already exists" errors
- [ ] Verify project creation and database initialization work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)