### PR TITLE
Fix PostgREST test runner code replacement escaping

### DIFF
--- a/postgrest-test-runner.ts
+++ b/postgrest-test-runner.ts
@@ -501,7 +501,7 @@ class PostgRESTNodeTestRunner {
       .replace('<id>', example.id)
       .replace('<name>', example.name)
       .replace('<project_url>', this.config.supabaseLiteUrl)
-      .replaceAll('<code>', code)
+      .replaceAll('<code>', () => code)
       .replaceAll('<code_content>', escapedCodeContent)
       .replace('<response>', JSON.stringify(expectedResponse, null, 2))
       .replace("debugSqlEndpoint: 'http://localhost:5173/debug/sql'", `debugSqlEndpoint: '${this.config.supabaseLiteUrl}/debug/sql'`)


### PR DESCRIPTION
## Summary
- avoid template replacement interpreting special sequences when inserting example code in the PostgREST test runner

## Testing
- npm run lint *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d157b6ee408323b7f97a9ed4f66fff